### PR TITLE
Ajustar layout da página principal e remover elementos

### DIFF
--- a/Site PhP/index.php
+++ b/Site PhP/index.php
@@ -361,21 +361,7 @@ if ($gameSlug) {
             </div>
         </section>
 
-        <!-- Área principal com logo central -->
-        <div style="text-align: center; padding: 2rem 0; background: hsl(var(--background));">
-            <div style="width: 150px; height: 150px; margin: 0 auto 1rem; background: hsl(var(--muted)); border-radius: 50%; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden;">
-                <div style="width: 120px; height: 120px; border: 4px solid hsl(var(--border)); border-radius: 50%; background: hsl(var(--background)); display: flex; align-items: center; justify-content: center;">
-                    <i class="fas fa-play" style="font-size: 3rem; color: hsl(var(--primary)); margin-left: 0.5rem;"></i>
-                </div>
-                <!-- Ícone de busca sobreposto -->
-                <div style="position: absolute; top: -15px; right: -15px; width: 60px; height: 60px; background: hsl(var(--muted)); border-radius: 50%; display: flex; align-items: center; justify-content: center; border: 4px solid hsl(var(--background));">
-                    <i class="fas fa-search" style="font-size: 1.25rem; color: hsl(var(--muted-foreground));"></i>
-                </div>
-            </div>
-            
-            <h1 style="font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem;">Jogos Traduzidos</h1>
-            <p style="color: hsl(var(--muted-foreground)); font-size: 0.875rem;">Descubra os melhores jogos Ren'Py em português</p>
-        </div>
+        <!-- Espaço da home limpo (ícone e textos removidos) -->
 
         <!-- Grid de jogos -->
         <div class="container">

--- a/Site PhP/style.css
+++ b/Site PhP/style.css
@@ -233,20 +233,21 @@ body {
 .card-image {
     position: relative;
     width: 100%;
-    height: 160px;
-    overflow: hidden;
+    height: auto;
+    overflow: visible;
     background: hsl(var(--muted));
 }
 
 .card-image img {
     width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 0.3s ease;
+    height: auto;
+    object-fit: contain;
+    transition: none;
+    display: block;
 }
 
 .card:hover .card-image img {
-    transform: scale(1.05);
+    transform: none;
 }
 
 .card-content {
@@ -648,7 +649,7 @@ body {
     }
     
     .card-image {
-        height: 140px;
+        height: auto;
     }
     
     .admin-card-image {
@@ -675,7 +676,7 @@ body {
     }
     
     .card-image {
-        height: 200px;
+        height: auto;
     }
     
     .auth-card {


### PR DESCRIPTION
Display card images in original size without cropping and remove the hero section (play icon and text) from the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-87485aa0-1eac-41a0-8e8f-8a9154b236ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87485aa0-1eac-41a0-8e8f-8a9154b236ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

