### PR TITLE
Enable gif uploads and display

### DIFF
--- a/config.php
+++ b/config.php
@@ -545,8 +545,9 @@ function displayScreenshots($screenshots, $gameTitle = '', $gameId = '', $showTi
         $thumbnailPath = "uploads/screenshots/thumb_" . $screenshot;
         $alt = $gameTitle ? "$gameTitle - Screenshot " . ($index + 1) : "Screenshot " . ($index + 1);
         
-        // Usar thumbnail se existir
-        $displayPath = file_exists($thumbnailPath) ? $thumbnailPath : $imagePath;
+        // Usar thumbnail se existir, exceto para GIF (mantém animação)
+        $isGif = strtolower(pathinfo($screenshot, PATHINFO_EXTENSION)) === 'gif';
+        $displayPath = $isGif ? $imagePath : (file_exists($thumbnailPath) ? $thumbnailPath : $imagePath);
         
         $html .= "<div class='screenshot-item' data-index='{$index}' onclick='openModal(this.querySelector(\"img.screenshot\"), {$index})'>
                     <img src='{$displayPath}' 

--- a/dashboard.php
+++ b/dashboard.php
@@ -67,6 +67,9 @@ if ($action === 'create_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         $screenshots = uploadMultipleFiles($_FILES['screenshots'], 'uploads/screenshots/', MAX_SCREENSHOTS);
     }
 
+    // Adicionar mensagens detalhadas de upload (se houver)
+    $uploadErrors = function_exists('pullUploadErrors') ? pullUploadErrors() : '';
+
     if (!$errors) {
         // Criar slug único
         $slugBase = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $_POST['title'])));
@@ -127,11 +130,13 @@ if ($action === 'create_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         ]);
 
         $message = $result 
-            ? "<div class='alert alert-success'><i class='fas fa-check'></i> Jogo criado com sucesso!</div>"
+            ? "<div class='alert alert-success'><i class='fas fa-check'></i> Jogo criado com sucesso!" . ($uploadErrors ? ('<br>' . nl2br(htmlspecialchars($uploadErrors))) : '') . "</div>"
             : "<div class='alert alert-error'>Erro ao criar jogo.</div>";
         $action = 'home';
     } else {
-        $message = "<div class='alert alert-error'><i class='fas fa-times'></i> " . implode('<br>', $errors) . "</div>";
+        $msg = implode('<br>', $errors);
+        if ($uploadErrors) $msg .= '<br>' . nl2br(htmlspecialchars($uploadErrors));
+        $message = "<div class='alert alert-error'><i class='fas fa-times'></i> {$msg}</div>";
     }
 }
 
@@ -220,6 +225,8 @@ if ($action === 'update_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     
     if ($ok) {
         $noticeText = $uploadNotices ? ('<br>' . implode('<br>', $uploadNotices)) : '';
+        $uploadErrors = function_exists('pullUploadErrors') ? pullUploadErrors() : '';
+        if ($uploadErrors) $noticeText .= '<br>' . nl2br(htmlspecialchars($uploadErrors));
         $message = "<div class='alert alert-success'><i class='fas fa-check'></i> Jogo atualizado!{$noticeText}</div>";
     } else {
         $message = "<div class='alert alert-error'>Erro ao atualizar</div>";

--- a/dashboard.php
+++ b/dashboard.php
@@ -424,7 +424,7 @@ if ($action === 'delete_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
                         
                         <div class="form-group">
                             <label for="cover_image">Imagem URL *</label>
-                            <input type="file" id="coverInput" name="cover_image" accept="image/*" required>
+                            <input type="file" id="coverInput" name="cover_image" accept="image/*,.gif" required>
                             <div id="coverPreview" style="margin-top:.5rem"></div>
                         </div>
                         
@@ -474,7 +474,7 @@ if ($action === 'delete_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
 
                         <div class="form-group">
                             <label>Imagens Extras (até 30)</label>
-                            <input id="screenshotsInput" type="file" name="screenshots[]" accept="image/*" multiple>
+                            <input id="screenshotsInput" type="file" name="screenshots[]" accept="image/*,.gif" multiple>
                             <div id="screenshotsPreview" style="margin-top:.5rem"></div>
                         </div>
 
@@ -597,7 +597,7 @@ if ($action === 'delete_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
                             </div>
                         </div>
                         <div class="form-group"><label>Descrição</label><textarea name="description" rows="4"><?= htmlspecialchars($eg['description']) ?></textarea></div>
-                        <div class="form-group"><label>Capa</label><input id="editCoverInput" type="file" name="cover_image" accept="image/*"><div id="editCoverPreview" style="margin-top:.5rem"></div></div>
+                        <div class="form-group"><label>Capa</label><input id="editCoverInput" type="file" name="cover_image" accept="image/*,.gif"><div id="editCoverPreview" style="margin-top:.5rem"></div></div>
                         <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
                             <div class="form-group"><label>Versão</label><input type="text" name="version" value="<?= htmlspecialchars($eg['version']) ?>"></div>
                             <div class="form-group"><label>Idiomas</label>
@@ -643,7 +643,7 @@ if ($action === 'delete_game' && $_SERVER['REQUEST_METHOD'] === 'POST') {
                         </div>
                         <?php endif; ?>
 
-                        <div class="form-group"><label>Imagens extras (adicionar novas)</label><input id="editScreenshotsInput" type="file" name="screenshots[]" multiple accept="image/*"><div id="editScreenshotsPreview" style="margin-top:.5rem"></div></div>
+                        <div class="form-group"><label>Imagens extras (adicionar novas)</label><input id="editScreenshotsInput" type="file" name="screenshots[]" multiple accept="image/*,.gif"><div id="editScreenshotsPreview" style="margin-top:.5rem"></div></div>
                         <div class="form-group" style="margin-top:.25rem">
                             <label style="display:flex;align-items:center;gap:.5rem;"><input type="checkbox" name="replace_all" value="1"> Substituir todas as imagens existentes por estas novas</label>
                         </div>


### PR DESCRIPTION
Enable GIF uploads and display by updating file input `accept` attributes and ensuring GIFs are displayed in their original animated form.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e0515b0-964f-4b6c-99de-4835cbca648f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e0515b0-964f-4b6c-99de-4835cbca648f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

