### PR TITLE
Secure PHP website with .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,9 @@
 # Security and performance
-Options -Indexes
+Options -Indexes -ExecCGI -Includes -MultiViews
 FileETag None
 <IfModule mod_headers.c>
 	Header unset ETag
+	Header unset X-Powered-By
 	Header set X-Content-Type-Options "nosniff"
 	Header set X-Frame-Options "DENY"
 	Header set X-XSS-Protection "1; mode=block"
@@ -27,3 +28,77 @@ AddType image/svg+xml .svg
 <IfModule mod_deflate.c>
 	AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/javascript application/json image/svg+xml
 </IfModule>
+
+# --- Harden: Block traversal and null bytes in query ---
+<IfModule mod_rewrite.c>
+	RewriteCond %{QUERY_STRING} (\.|%2e){2}/ [NC,OR]
+	RewriteCond %{QUERY_STRING} (\x00|%00) [NC]
+	RewriteRule .* - [F]
+</IfModule>
+# --- Harden: Force HTTPS (considers proxy) ---
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	RewriteCond %{HTTPS} !=on [OR]
+	RewriteCond %{HTTP:X-Forwarded-Proto} !https
+	RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+</IfModule>
+
+# --- Harden: Restrict dangerous HTTP methods ---
+<IfModule mod_authz_core.c>
+	<LimitExcept GET POST HEAD OPTIONS>
+		Require all denied
+	</LimitExcept>
+</IfModule>
+<IfModule mod_rewrite.c>
+	RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK|DELETE|PUT|CONNECT)$ [NC]
+	RewriteRule .* - [F]
+</IfModule>
+
+# --- Harden: Deny access to hidden files and sensitive resources ---
+<FilesMatch "^\.">
+	Require all denied
+</FilesMatch>
+<Files "config.php">
+	Require all denied
+</Files>
+<FilesMatch "(?i)^(composer\.(json|lock)|package\.json|yarn\.lock|phpunit\.xml|\.env(\..*)?|Dockerfile|docker-compose\.yml|Makefile|README\.md|LICENSE|.*\.(sql|ini|log|bak|swp|sh))$">
+	Require all denied
+</FilesMatch>
+<FilesMatch "(?i)_partial\.php$">
+	Require all denied
+</FilesMatch>
+# Block VCS directories
+<IfModule mod_rewrite.c>
+	RewriteRule (?i)\.(git|svn|hg|bzr)(/|$) - [R=404,L]
+</IfModule>
+
+# --- Harden: Prevent PHP execution from uploads via root path (defense in depth) ---
+<IfModule mod_rewrite.c>
+	RewriteRule ^uploads/.*\.(php[0-9]?|phtml|phar)$ - [F,L]
+</IfModule>
+
+# --- Harden: Secure headers ---
+<IfModule mod_headers.c>
+	Header always set Referrer-Policy "strict-origin-when-cross-origin"
+	Header always set Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=(), usb=()"
+	Header always set Cross-Origin-Resource-Policy "same-origin"
+	Header always set Cross-Origin-Opener-Policy "same-origin"
+	Header always set X-Permitted-Cross-Domain-Policies "none"
+	Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
+	Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+</IfModule>
+
+# --- Harden: PHP runtime flags when using mod_php ---
+<IfModule mod_php.c>
+	php_flag display_errors Off
+	php_flag log_errors On
+	php_value error_reporting 30711
+	php_value session.cookie_httponly 1
+	php_value session.cookie_secure 1
+	php_value session.use_strict_mode 1
+	php_value session.use_only_cookies 1
+	php_value session.cookie_samesite Lax
+</IfModule>
+
+# --- Harden: Misc ---
+ServerSignature Off

--- a/.user.ini
+++ b/.user.ini
@@ -1,0 +1,22 @@
+; Security hardening for PHP in userland
+expose_php = Off
+; Don't reveal errors to users
+display_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; Session security
+session.cookie_httponly = 1
+session.cookie_secure = 1
+session.use_strict_mode = 1
+session.use_only_cookies = 1
+session.cookie_samesite = Lax
+
+; File uploads constraints
+file_uploads = On
+upload_max_filesize = 64M
+post_max_size = 64M
+max_file_uploads = 60
+
+; Disable potentially dangerous functions (adjust per app needs)
+disable_functions = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,parse_ini_file,show_source

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,38 @@
+# Deny script execution in uploads
+<IfModule mod_mime.c>
+	RemoveHandler .php .php3 .php4 .php5 .php7 .php8 .phtml .phar
+	RemoveType .php .php3 .php4 .php5 .php7 .php8 .phtml .phar
+</IfModule>
+<IfModule mod_php.c>
+	php_flag engine off
+</IfModule>
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	RewriteRule ^.*\.(php[0-9]?|phtml|phar)$ - [F,L]
+</IfModule>
+
+# Only allow safe methods
+<LimitExcept GET HEAD>
+	Require all denied
+</LimitExcept>
+
+# Block listing
+Options -Indexes
+
+# Force download for potentially dangerous but allowed types
+<IfModule mod_headers.c>
+	Header set X-Content-Type-Options "nosniff"
+</IfModule>
+AddType application/octet-stream .svg .xml .json
+
+# Cache control for static uploads
+<IfModule mod_expires.c>
+	ExpiresActive On
+	ExpiresByType image/jpg "access plus 1 month"
+	ExpiresByType image/jpeg "access plus 1 month"
+	ExpiresByType image/gif "access plus 1 month"
+	ExpiresByType image/png "access plus 1 month"
+	ExpiresByType image/webp "access plus 1 month"
+	ExpiresByType image/avif "access plus 1 month"
+	ExpiresByType image/svg+xml "access plus 1 month"
+</IfModule>


### PR DESCRIPTION
Apply comprehensive security hardening via `.htaccess` and `.user.ini` to protect the PHP website for hosting.

---
<a href="https://cursor.com/background-agent?bcId=bc-74fa142f-5a9f-4892-bc6b-013fb4983462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74fa142f-5a9f-4892-bc6b-013fb4983462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

